### PR TITLE
Add MySQL healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Available targets:
 | `amqp` | Use `amqplib.connect` to establish a connection to an AMQP broker | `amqplib` | [`amqp://username:password@host:port/vhost?query`](http://www.rabbitmq.com/uri-spec.html) | *none* | `amqp://rabbitmq:5672` |
 | `rabbitmq` | Extends `amqp` to connection to RabbitMQ | `amqplib` | `rabbitmq[://username:password@host:port]` | `rabbitmq://localhost:5672` | `rabbitmq` |
 | `redis` | Connects to a Redis service with `redis.createClient` | `redis` | `redis[://username:password@host:port/vhost?query]` | `redis://localhost6389` | |`redis` |
+| `mysql` | Connects to a MySQL service with `mysql.createConnection` | `mysql` | `mysql://username:password@host:port/database` | *none* | `mysql://root:root@localhost:3306/mysql` |`mysql` |
 
 *Note: The npm Dependency with `npm install` is required to be installed for the healthcheck to work.*
 

--- a/src/healthchecks/index.js
+++ b/src/healthchecks/index.js
@@ -2,3 +2,4 @@ export tcp from "./tcp";
 export amqp from "./amqp";
 export rabbitmq from "./rabbitmq";
 export redis from "./redis";
+export mysql from "./mysql";

--- a/src/healthchecks/mysql.js
+++ b/src/healthchecks/mysql.js
@@ -1,0 +1,31 @@
+import Promise from "bluebird";
+import HealthcheckError from "../lib/HealthcheckError";
+
+const MYSQL_DEPENDENCY = "mysql";
+
+export default function mysql(target) {
+    return Promise.try(() => System.import(MYSQL_DEPENDENCY)).then(mysql => {
+        const connection = mysql.createConnection(target);
+
+        return new Promise((resolve, reject) => {
+            connection.connect((err) => {
+                if (err) {
+                    reject(err);
+                }
+
+                resolve();
+            });
+        }).finally(() => {
+            connection.end();
+        });
+    }).catch(err => {
+        switch (err.code) {
+        case "PROTOCOL_CONNECTION_LOST":
+            return;
+        case "ECONNREFUSED":
+            throw new HealthcheckError("mysql", target, HealthcheckError.CONNECTION_FAILUE, "Unable to connect to MySQL server", err);
+        default:
+            throw err;
+        }
+    });
+}


### PR DESCRIPTION
This PR adds a MySQL healthcheck that uses the `mysql` node module to check that the database can be connected to.